### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -427,7 +427,7 @@ You should only need `makePersistable` but this library also provides other util
 >     makePersistable(this, { name: 'SampleStore', properties: ['someProperty'] });
 >   }
 >
->   async clearStoredDate() {
+>   async clearStoredData() {
 >     await clearPersistedStore(this);
 >   }
 > }


### PR DESCRIPTION
The `README.md` file contains a typo in the method name. This PR corrects it from `clearStoredDate` to `clearStoredData`.